### PR TITLE
feat: add find_similar_works tool for semantic search

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -127,6 +127,14 @@ export const searchSourcesSchema = z.object({
   per_page: z.number().positive().max(200).optional(),
 });
 
+export const findSimilarWorksSchema = z.object({
+  query: z.string().min(1).max(10000),
+  count: z.number().positive().max(100).optional(),
+  from_publication_year: z.number().positive().optional(),
+  to_publication_year: z.number().positive().optional(),
+  is_oa: z.boolean().optional(),
+});
+
 export function validateInput<T>(schema: z.ZodSchema<T>, data: unknown, context: string): T {
   try {
     return schema.parse(data);


### PR DESCRIPTION
## Summary

- Adds a new `find_similar_works` MCP tool that uses OpenAlex's `/find/works` endpoint for AI embedding-based semantic search
- Finds conceptually related works even when different terminology is used (unlike keyword search)
- Requires `OPENALEX_API_KEY` (costs 1,000 credits per query)

## Changes

**4 files changed, 256 insertions, 1 deletion** — minimal diff for easy upstream merge.

### `src/openalex-client.ts`
- Added `FindSimilarWorksOptions` interface (`query`, `count`, `filter`)
- Added `findSimilarWorks()` method hitting `/find/works` with auth, caching, retry, and filter serialization (consistent with existing methods)

### `src/validation.ts`
- Added `findSimilarWorksSchema` — validates `query` (1-10,000 chars), `count` (1-100), `from_publication_year`, `to_publication_year`, `is_oa`

### `src/index.ts`
- Added `find_similar_works` tool definition in the "Literature Search & Discovery" section
- Added handler with Zod validation, publication year filter construction (range/gt/lt), and response formatting using existing `summarizeWork()` — each result includes a similarity `score` (0-1)

### `tests/client.test.ts`
- 5 new unit tests: basic query, count + filter params, empty results, caching, and API key auth

## Testing

- `npx tsc` — compiles with zero errors
- `npx vitest run` — all 21 tests pass (16 client + 5 validation)

## API Reference

Based on [OpenAlex /find/works docs](https://docs.openalex.org/how-to-use-the-api/find-similar-works):
- **Endpoint**: `GET /find/works?query=...&count=...&filter=...`
- **Returns**: Works ranked by similarity score (0-1), using GTE-Large embeddings over ~217M works with abstracts
- **Filters**: `publication_year`, `is_oa`, `has_abstract`, `has_content.pdf`, `has_content.grobid_xml`