### PR TITLE
Fix 404 error when looking up works by DOI or URL

### DIFF
--- a/tests/id-normalization.test.ts
+++ b/tests/id-normalization.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import axios from 'axios';
+import { OpenAlexClient } from '../src/openalex-client.js';
+
+vi.mock('axios');
+
+function createMockAxios(mockGet: any) {
+  return {
+    get: mockGet,
+    interceptors: {
+      response: {
+        use: vi.fn(),
+      },
+    },
+  };
+}
+
+describe('OpenAlexClient ID normalization', () => {
+  it('should pass OpenAlex IDs as-is', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { id: 'W12345' } });
+    vi.mocked(axios.create).mockReturnValue(createMockAxios(mockGet) as any);
+
+    const client = new OpenAlexClient({ enableCache: false });
+    await client.getEntity('works', 'W12345');
+
+    expect(mockGet).toHaveBeenCalledWith('/works/W12345', expect.any(Object));
+  });
+
+  it('should prefix bare DOIs with "doi:" to prevent path splitting', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { id: 'W99' } });
+    vi.mocked(axios.create).mockReturnValue(createMockAxios(mockGet) as any);
+
+    const client = new OpenAlexClient({ enableCache: false });
+    await client.getEntity('works', '10.48550/arXiv.2403.13093');
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/works/doi:10.48550/arXiv.2403.13093',
+      expect.any(Object)
+    );
+  });
+
+  it('should prefix standard DOIs with "doi:"', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { id: 'W100' } });
+    vi.mocked(axios.create).mockReturnValue(createMockAxios(mockGet) as any);
+
+    const client = new OpenAlexClient({ enableCache: false });
+    await client.getEntity('works', '10.1371/journal.pone.0000000');
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/works/doi:10.1371/journal.pone.0000000',
+      expect.any(Object)
+    );
+  });
+
+  it('should encode full DOI URLs to prevent absolute URL bypass', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { id: 'W200' } });
+    vi.mocked(axios.create).mockReturnValue(createMockAxios(mockGet) as any);
+
+    const client = new OpenAlexClient({ enableCache: false });
+    await client.getEntity('works', 'https://doi.org/10.48550/arXiv.2403.13093');
+
+    expect(mockGet).toHaveBeenCalledWith(
+      `/works/${encodeURIComponent('https://doi.org/10.48550/arXiv.2403.13093')}`,
+      expect.any(Object)
+    );
+  });
+
+  it('should encode arbitrary HTTPS URLs', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { id: 'W300' } });
+    vi.mocked(axios.create).mockReturnValue(createMockAxios(mockGet) as any);
+
+    const client = new OpenAlexClient({ enableCache: false });
+    await client.getEntity('works', 'https://proceedings.mlr.press/v206/pattathil23a.html');
+
+    expect(mockGet).toHaveBeenCalledWith(
+      `/works/${encodeURIComponent('https://proceedings.mlr.press/v206/pattathil23a.html')}`,
+      expect.any(Object)
+    );
+  });
+
+  it('should leave "doi:" prefixed IDs as-is', async () => {
+    const mockGet = vi.fn().mockResolvedValue({ data: { id: 'W400' } });
+    vi.mocked(axios.create).mockReturnValue(createMockAxios(mockGet) as any);
+
+    const client = new OpenAlexClient({ enableCache: false });
+    await client.getEntity('works', 'doi:10.48550/arXiv.2403.13093');
+
+    expect(mockGet).toHaveBeenCalledWith(
+      '/works/doi:10.48550/arXiv.2403.13093',
+      expect.any(Object)
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`get_work` (and any tool using `getEntity`) returns 404 when the ID is a bare DOI or a full URL. This affects two cases:

### Bare DOIs (e.g. `10.48550/arXiv.2403.13093`)

The slash in the DOI is interpreted as a path separator, so axios sends:
```
GET /works/10.48550/arXiv.2403.13093
```
The API sees three path segments instead of one entity ID → 404.

### Full URLs (e.g. `https://doi.org/10.48550/arXiv.2403.13093`)

Axios detects an absolute URL and uses it directly as the request URL, bypassing the `baseURL` entirely — the request never reaches `api.openalex.org` → 404.

### Reproduction against the live API

```bash
# Bare DOI — 404
curl -s -o /dev/null -w "%{http_code}" "https://api.openalex.org/works/10.48550/arXiv.2403.13093"
# 404

# With doi: prefix — 200
curl -s -o /dev/null -w "%{http_code}" "https://api.openalex.org/works/doi:10.48550/arXiv.2403.13093"
# 200

# Full DOI URL — 200
curl -s -o /dev/null -w "%{http_code}" "https://api.openalex.org/works/https://doi.org/10.48550/arXiv.2403.13093"
# 200
```

## Fix

Add `normalizeId()` to `getEntity` that:
- Prefixes bare DOIs (matching `10.\d{4,9}/`) with `doi:` — the format OpenAlex natively accepts
- Percent-encodes full URLs (`https://...`) so they remain a single path segment instead of being treated as absolute URLs by axios
- Leaves OpenAlex IDs (`W...`) and already-prefixed IDs (`doi:...`) untouched

## Test plan

- [x] 6 unit tests added (`tests/id-normalization.test.ts`) covering: OpenAlex IDs, bare DOIs, standard DOIs, full DOI URLs, arbitrary HTTPS URLs, and `doi:`-prefixed IDs
- [x] All existing tests continue to pass
- [x] Verified against live OpenAlex API (curl results above)